### PR TITLE
fix: exert backpressure when concurrency level is reached

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ export class Parallel extends TransformStream {
           .catch(error => controller.error(error))
         // if at concurrency limit, wait for a pending task to complete
         if (pending === concurrency) {
+          // returning a promise here prevents transform from being called
+          // again until it resolves i.e. backpressure
           return new Promise(resolve => { onNext = resolve })
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0 OR MIT",
       "devDependencies": {
         "c8": "^8.0.1",
-        "entail": "^2.1.1",
+        "entail": "^2.1.2",
         "p-defer": "^4.0.0",
         "standard": "^17.1.0"
       }
@@ -670,9 +670,9 @@
       "dev": true
     },
     "node_modules/entail": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/entail/-/entail-2.1.1.tgz",
-      "integrity": "sha512-gF0oq4AOVm/3cyBvp8y1jOFc7DGRlatJQnGWkwyAxdNGle0UjtRTwaIUNiTZ88a7Q+wKZb0vtdqc5O7L5W7H/A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/entail/-/entail-2.1.2.tgz",
+      "integrity": "sha512-/icW51VHeJo5j6z6/80vO6R7zAdvHDODHYcc2jItrhRvP/zfTlm2b+xcEkp/Vt3UI6R5651Stw0AGpE1Gzkm6Q==",
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0 OR MIT",
   "devDependencies": {
     "c8": "^8.0.1",
-    "entail": "^2.1.1",
+    "entail": "^2.1.2",
     "p-defer": "^4.0.0",
     "standard": "^17.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -36,7 +36,6 @@ export const test = {
       pull (controller) {
         const value = input.shift()
         if (value == null) return controller.close()
-        console.log({ running, maxRunning })
         running++
         maxRunning = Math.max(running, maxRunning)
         controller.enqueue(value)


### PR DESCRIPTION
Previously this module was _running_ up to N transform tasks concurrently, but while those tasks were running it buffered the rest of the stream data internally 🤦 .